### PR TITLE
Remove mention of jsonfilter from the trim objects problem

### DIFF
--- a/problems/trim_objects/problem.md
+++ b/problems/trim_objects/problem.md
@@ -28,5 +28,3 @@ with the keys and values trimmed.
 Use the command **data-plumber verify package.json** to verify.
 
 Use the command **data-plumber run package.json** to see the raw gasket output.
-
-**Hint**: use the jsonfilter again for this challenge in addition to csv-parser


### PR DESCRIPTION
There was a still a line in the problem.md for the trim objects problem that gave a hint to use jsonfilter. Since it's no longer valid, I removed the line.
