### PR TITLE
Update xml answer to work with latest version of xml-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "trim-object-stream": "^1.0.0",
     "tuple-stream": "0.0.2",
     "win-spawn": "^2.0.0",
-    "xml-json": "^1.0.0"
+    "xml-json": "^2.0.2"
   },
   "repository": {
     "type": "git",

--- a/problems/xml/package.json
+++ b/problems/xml/package.json
@@ -2,11 +2,11 @@
   "name": "my-module",
   "version": "0.0.1",
   "gasket": [
-    "xml-json",
-    "jsonfilter body.vehicle.*.$.id"
+    "xml-json vehicle",
+    "jsonfilter id"
   ],
   "dependencies": {
-    "xml-json": "^1.0.0",
+    "xml-json": "^2.0.2",
     "jsonfilter": "^1.0.1"
   }
 }


### PR DESCRIPTION
[`xml-json`](https://github.com/maxogden/xml-json)'s API changed a little when updating to 2.0.0 so the answer to XML is no longer valid, unless the user installs `xml-json@1.0.0` specifically.

This updates the answer to reflect that API change with the added bonus of a cleaner `jsonfilter` call.
